### PR TITLE
Catch additional exception

### DIFF
--- a/ByakuGallery/src/com/diegocarloslima/byakugallery/lib/TileBitmapDrawable.java
+++ b/ByakuGallery/src/com/diegocarloslima/byakugallery/lib/TileBitmapDrawable.java
@@ -419,6 +419,8 @@ public class TileBitmapDrawable extends Drawable {
                 // We're under memory pressure. Let's try again with a smaller size
                 options.inSampleSize <<= 1;
                 screenNail = decoder.decodeRegion(screenNailRect, options);
+            } catch (Exception e) {
+                return e;
             }
 
             try {


### PR DESCRIPTION
There are occasional NPE when calling createScaledBitmap inside of the
try/catch for OOM.
