### PR TITLE
fix of memory leaking

### DIFF
--- a/ByakuGallery/src/com/diegocarloslima/byakugallery/lib/TouchImageView.java
+++ b/ByakuGallery/src/com/diegocarloslima/byakugallery/lib/TouchImageView.java
@@ -209,6 +209,13 @@ public class TouchImageView extends ImageView {
 	}
 
 	@Override
+	protected void onDetachedFromWindow() {
+		super.onDetachedFromWindow();
+		mDrawable = null;
+		super.setImageDrawable(mDrawable);
+	}
+
+	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 		final int oldMeasuredWidth = getMeasuredWidth();
 		final int oldMeasuredHeight = getMeasuredHeight();


### PR DESCRIPTION
Using your library I found an issue of memory leak. That's because ViewPager does not remove ImageView from FragmentManager. You can see that printing dump of FragmentManager. So I remove a link between ImageView and Bitmap. Please check it.
Best Regard.
